### PR TITLE
fiks for ikke sjekk om postnr er i db:posts tabellen

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -52,7 +52,7 @@ class AuthController extends Controller
             'name' => 'required|max:255',
             'email' => 'required|email|max:255|unique:users',
             'address' => 'required|max:255',
-            'postnr' => 'required|digits:4',
+            'postnr' => 'required|digits:4|exists:posts,postnr',
             'phonenumber' => 'required|digits:8',
             'password' => 'required|min:6|confirmed',
         ]);


### PR DESCRIPTION
får fæl error hvis de prøver å registrere et postnr som ikke er i db
uten denne sjekken
